### PR TITLE
Make default run headless

### DIFF
--- a/wb/src/controller.ts
+++ b/wb/src/controller.ts
@@ -25,12 +25,13 @@ export class BrowserController {
 
   static async initialize(
     sessionName: string = "default",
+    debug: boolean = false,
   ): Promise<Result<void, BrowserError>> {
     if (
       !BrowserController.instance ||
       BrowserController.instance.sessionName !== sessionName
     ) {
-      const res = await ClientSocket.ensureSession(sessionName);
+      const res = await ClientSocket.ensureSession(sessionName, debug);
       if (res.isErr()) {
         return res;
       }

--- a/wb/src/index.ts
+++ b/wb/src/index.ts
@@ -11,9 +11,14 @@ program
     "Name of the session to use: default is 'default'",
     "default",
   )
+  .option(
+    "-d, --debug",
+    "Enable debug mode (makes the browser not headless)",
+    false,
+  )
   .hook("preAction", async (thisCommand) => {
     const options = thisCommand.opts();
-    BrowserController.initialize(options.session);
+    BrowserController.initialize(options.session, options.debug);
     const res = await ClientSocket.ensureSession(options.session);
     if (res.isErr()) {
       console.error(res.error);

--- a/wb/src/socket.ts
+++ b/wb/src/socket.ts
@@ -33,17 +33,20 @@ export class ClientSocket {
 
   static async ensureSession(
     sessionName: string,
+    debug: boolean = false,
   ): Promise<Result<void, BrowserError>> {
     return !fs.existsSync(socketPath(sessionName))
-      ? await ClientSocket.createSession(sessionName)
+      ? await ClientSocket.createSession(sessionName, debug)
       : ok(undefined);
   }
 
   static async createSession(
     sessionName: string,
+    debug: boolean = false,
   ): Promise<Result<void, BrowserError>> {
     // Spawn the browser process in detached mode to orphan it
-    const child = spawn("wbd", ["-s", sessionName], {
+    const options = (debug ? ["-d"] : []).concat(["-s", sessionName]);
+    const child = spawn("wbd", options, {
       detached: true,
       stdio: "ignore",
     });

--- a/wbd/src/index.ts
+++ b/wbd/src/index.ts
@@ -7,9 +7,10 @@ console.log("wbd daemon");
 
 program
   .option("-s, --session-name [name]", "Session name", "default")
+  .option("-d, --debug", "Enable debug mode", false)
   .action((options) => {
     console.log(`Starting daemon for session ${options.sessionName}`);
-    Session.initialize(options.sessionName);
+    Session.initialize(options.sessionName, options.debug);
   });
 
 program.parse();

--- a/wbd/src/session.ts
+++ b/wbd/src/session.ts
@@ -31,7 +31,10 @@ export class Session {
   public data: Record<string, any> = {};
   private stagehand: Stagehand;
 
-  private constructor(public sessionName: string = "default") {
+  private constructor(
+    public sessionName: string = "default",
+    debug: boolean = false,
+  ) {
     this.startTime = new Date();
     this.socket = new ServerSocket(sessionName);
     const dataDir = path.join(SESSION_DIR, sessionName, "data");
@@ -39,7 +42,7 @@ export class Session {
     this.stagehand = new Stagehand({
       env: "LOCAL",
       localBrowserLaunchOptions: {
-        headless: false,
+        headless: !debug,
         userDataDir: dataDir,
       },
     });
@@ -109,9 +112,12 @@ export class Session {
     );
   }
 
-  static async initialize(sessionName: string = "default") {
+  static async initialize(
+    sessionName: string = "default",
+    debug: boolean = false,
+  ) {
     if (!Session.instance || Session.instance.sessionName !== sessionName) {
-      Session.instance = new Session(sessionName);
+      Session.instance = new Session(sessionName, debug);
       await Session.instance.stagehand.init();
       Session.instance.socket.listen();
     }


### PR DESCRIPTION
Now, for debugging purposes we can pass the `-d` option to run the broweser visually, but by default it runs headless.