### PR TITLE
Make headless chrome work in containers

### DIFF
--- a/wbd/src/session.ts
+++ b/wbd/src/session.ts
@@ -44,6 +44,12 @@ export class Session {
       localBrowserLaunchOptions: {
         headless: !debug,
         userDataDir: dataDir,
+        args: [
+          '--no-sandbox',
+          '--disable-setuid-sandbox',
+          '--disable-dev-shm-usage',
+          '--disable-gpu',
+        ],
       },
     });
   }


### PR DESCRIPTION
Without setting these flags, `wb` fails when in a docker container.