### PR TITLE
Create script to retrieve cookies, loadable into a `wb` tab.

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -99,6 +99,7 @@ export const SESSION_METHODS = [
   "listTabs",
   "getCurrentTab",
   "setCurrentTab",
+  "addCookies",
   "newTab",
   "closeTab",
   "dump",

--- a/cookie-getter.ts
+++ b/cookie-getter.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import { chromium } from "playwright-core";
+import { Command } from "commander";
+import { writeFile } from "node:fs/promises";
+
+const program = new Command("cookie-getter")
+  .option("-c, --cookies", "File to store cookies to", "cookies.json")
+  .action(async (options) => {
+    const browser = await chromium.launch({
+      headless: false,
+    });
+    let it = 0;
+    while (!browser.isConnected() && it < 300) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      it++;
+    }
+    if (!browser.isConnected()) {
+      console.log("Could not connect...timed out");
+      process.exit(1);
+    }
+
+    const page = await browser.newPage();
+
+    await new Promise<void>((resolve) => {
+      page.on("close", async (_) => {
+        const cookies = (await Promise.all(browser.contexts().map(async c => await c.cookies()))).flat();
+        const json = JSON.stringify(cookies);
+        await writeFile(options.cookies, json);
+        console.log(`Cookies written to ${options.cookies}`);
+        resolve();
+      });
+    });
+    process.exit(0);
+  });
+
+program.parse();

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@browserbasehq/stagehand": "^3.0.3",
     "dotenv": "^16.6.1",
     "jiti": "^2.6.1",
+    "playwright": "^1.56.1",
     "turndown": "^7.2.2",
     "typescript-eslint": "^8.47.0"
   }

--- a/wb/src/controller.ts
+++ b/wb/src/controller.ts
@@ -11,6 +11,7 @@ import {
 import { SESSION_DIR } from "@browse/common/constants";
 import fs from "fs";
 import path from "path";
+import { Cookie } from "playwright";
 
 export class BrowserController {
   private socket: ClientSocket;
@@ -78,7 +79,7 @@ export class BrowserController {
       // Session already deleted or never created
     } else if (!fs.existsSync(path.join(sessionPath, "sock"))) {
       // Socket file non-existent, just delete data
-      fs.rm(sessionPath, { recursive: true }, () => {});
+      fs.rmSync(sessionPath, { recursive: true });
     } else {
       const socketRes = await ClientSocket.connect(sessionName);
       // If you cannot connect, then the socket is stale
@@ -86,7 +87,7 @@ export class BrowserController {
         await socketRes.value.deleteSession();
       }
       // Delete all session data & socket file
-      fs.rm(sessionPath, { recursive: true }, () => {});
+      fs.rmSync(sessionPath, { recursive: true });
     }
     return ok(undefined);
   }
@@ -140,6 +141,15 @@ export class BrowserController {
     const res = await BrowserController.send("setCurrentTab", {
       tabName,
     });
+    if (res.isErr()) {
+      return res;
+    } else {
+      return ok(undefined);
+    }
+  }
+
+  static async addCookies(cookies: Cookie[]): Promise<Result<void>> {
+    const res = await BrowserController.send("addCookies", { cookies });
     if (res.isErr()) {
       return res;
     } else {

--- a/wbd/src/types.ts
+++ b/wbd/src/types.ts
@@ -1,4 +1,5 @@
 import { Dump, Go, Interact } from "@browse/common/types";
+import { Cookie } from "playwright";
 
 export function isTabInput(params: any): params is { tabName: string } {
   return typeof params === "object" && "tabName" in params;
@@ -13,6 +14,48 @@ export function isNewTabInput(
     typeof params.tabName === "string" &&
     "url" in params &&
     typeof params.url === "string"
+  );
+}
+
+export function isCookieInput(params: any): params is { cookies: Cookie[] } {
+  /*
+  Cookie {
+    name: string;
+    value: string;
+    domain: string;
+    path: string;
+    expires: number;
+    httpOnly: boolean;
+    secure: boolean;
+    sameSite: "Strict"|"Lax"|"None";
+    partitionKey?: string;
+  }
+  */
+  return (
+    "cookies" in params &&
+    Array.isArray(params.cookies) &&
+    params.cookies.every(
+      (cookie: any): cookie is Cookie =>
+        "name" in cookie &&
+        typeof cookie.name === "string" &&
+        "value" in cookie &&
+        typeof cookie.value === "string" &&
+        "domain" in cookie &&
+        typeof cookie.domain === "string" &&
+        "path" in cookie &&
+        typeof cookie.path === "string" &&
+        "expires" in cookie &&
+        typeof cookie.expires === "number" &&
+        "httpOnly" in cookie &&
+        typeof cookie.httpOnly === "boolean" &&
+        "secure" in cookie &&
+        typeof cookie.secure === "boolean" &&
+        "sameSite" in cookie &&
+        ["Strict", "Lax", "None"].includes(cookie.sameSite) &&
+        ("partitionKey" in cookie
+          ? typeof cookie.partitionKey === "string"
+          : true),
+    )
   );
 }
 

--- a/wbd/src/utils.ts
+++ b/wbd/src/utils.ts
@@ -1,6 +1,7 @@
 import { err, ok, Result } from "@browse/common/error";
 import { InteractResult } from "@browse/common/types";
 import { Page, Stagehand } from "@browserbasehq/stagehand";
+import { Cookie } from "playwright";
 
 export async function safeGoto(page: Page, url: string): Promise<Result<Page>> {
   try {
@@ -12,6 +13,27 @@ export async function safeGoto(page: Page, url: string): Promise<Result<Page>> {
     return err(e);
   }
   return ok(page);
+}
+
+export async function safeAddCookies(
+  stagehand: Stagehand,
+  cookies: Cookie[],
+): Promise<Result<void>> {
+  try {
+     const pg = stagehand.context.pages().length > 0 ? stagehand.context.pages()[0] : undefined;
+     if (!pg) {
+       console.log("No page to add cookies to");
+       return ok(undefined);
+     }
+    for (const cookie of cookies) {
+      const resp = await pg.sendCDP("Network.setCookie", cookie)
+      console.log(resp);
+    }
+    // let the cookies take effect
+    return ok(undefined);
+  } catch (e: any) {
+    return err(e);
+  }
 }
 
 export async function safeContent(page: Page): Promise<Result<string>> {


### PR DESCRIPTION
Workflow:

1. run `npx tsx cookie-getter.ts`
This launches a browser, you can navigate, this will work as long as you stay on the same tab, you can e.g. log in to a website, accept cookies on a page, etc...
2. Close the window, a `cookies.json` file will be saved with the cookies from the session.
3. With `wb` you can noe on the current tab, run `wb tab add-cookies cookies.json` and this will load the cookies into the current tab and reload the page.